### PR TITLE
Fixes for Sumo

### DIFF
--- a/src/configure_edison
+++ b/src/configure_edison
@@ -566,7 +566,7 @@ def showWiFiIP():
 def showWiFiMode():
     modestr = ''
     try:
-        modestr = subprocess.check_output('iwconfig wlan0 | grep Mode:', shell=True)
+        modestr = subprocess.check_output('iw wlan0 info | grep type', shell=True)
     except subprocess.CalledProcessError:
         print >> sys.stderr, "No interface found."
         return "none"
@@ -575,11 +575,13 @@ def showWiFiMode():
         print >> sys.stderr, inst
         return "none"
 
-    startIdx = modestr.find('Mode:')
+    startIdx = modestr.find('type')
     if (startIdx == -1):
          return "none"
-    modestr = modestr[modestr.find('Mode:')+5:].split()[0]
-    return modestr
+    startIdx = modestr.find('AP')
+    if (startIdx == -1):
+         return "Managed"
+    return "Master"
 
 def getCurrentFirmwareInfo():
     f = open('/etc/version','r')

--- a/src/server.js
+++ b/src/server.js
@@ -346,7 +346,7 @@ function inWhiteList(path) {
     return false;
   // if shell command succeeds and in host AP mode
   var result = shell.exec('configure_edison --showWiFiMode', {silent:true});
-  if ((result.code != 0) || (result.output.trim() === "Master")) {
+  if ((result.code != 0) || (result.stdout.trim() === "Master")) {
     return true;
   }
   return WHITELIST_PATHS[path] || WHITELIST_CMDS[path];
@@ -374,7 +374,7 @@ function requestHandler(req, res) {
     res.setHeader('Access-Control-Allow-Origin', '*');
 
     var result = shell.exec('configure_edison --showWiFiMode', {silent:true});
-    if ((result.code != 0) || (result.output.trim() != "Master")) {
+    if ((result.code != 0) || (result.stdout.trim() != "Master")) {
       var res_str = fs.readFileSync(site + '/status.html', {encoding: 'utf8'});
       var myhostname, myipaddr;
       exec('configure_edison --showWiFiIP', function (error, stdout, stderr) {
@@ -436,7 +436,7 @@ exec('configure_edison --showNames', function (error, stdout, stderr) {
         }
       });
       var result = shell.exec('configure_edison --isRestartWithAPSet', {silent:true});
-      if ((result.code != 0) || (result.output.trim() === "True")) {
+      if ((result.code != 0) || (result.stdout.trim() === "True")) {
         exec('configure_edison --enableOneTimeSetup', function (error, stdout, stderr) {
           if (error) {
             console.log("Error starting out-of-box-experience.");


### PR DESCRIPTION
This changes dependency from 'iwconfig' to 'iw', fixes the path for hostapd.conf
and fixes shelljs 'shell.exec' returning 'stdou't instead of 'output' in nodejs (8.9.4 in Sumo)

It does not yet show the list of available AP's