### PR TITLE
Make wired + bt connections work

### DIFF
--- a/src/configure_edison
+++ b/src/configure_edison
@@ -300,7 +300,7 @@ def _getPrivateService(type):
 
 def _getCachedService(service):
     global _cachedServices
-    
+
     for i in _cachedServices:
         if i[2] == service:
             return i[1]
@@ -773,7 +773,7 @@ def changePassword(newPass):
     pass_done.close()
     print("First-time root password setup complete. Enabling SSH on WiFi interface.")
     subprocess.call("sed -i 's/^BindToDevice=/# BindToDevice=/g' /lib/systemd/system/sshd.socket ; sync ; systemctl daemon-reload; systemctl restart sshd.socket", shell=True)
-    
+
 def changeName(newName):
     if _checkName(newName) < 0:
         print("Invalid new name. Ignoring")
@@ -992,7 +992,7 @@ def wireless_form():
     if WiFiMode == "AP":
         _setWiFiMode("Powered")
     elif WiFiMode == "Connected":
-        WiFi_mode = "Checked"
+        WiFi_mode = "checked"
         WiFi_IP = _getIFaceIP("wlan0")
     elif WiFiMode == "Powered":
         WiFi_IP = "WiFi is powered but inactive"
@@ -1014,19 +1014,19 @@ def wireless_form():
         if WiFiMode != _getWiFiMode():
             _setWiFiMode(WiFiMode)
     if ReloadMode == True:
-        return template('wirelessr',  
+        return template('wirelessr',
                     WiFi_mode = WiFi_mode, rows = connections, WiFi_IP = WiFi_IP, WiFi_Passphrase = "!@#$%^&*", WiFi_State = WiFi_State, Host_IP = Host_IP)
     else:
-        return template('wireless',  
+        return template('wireless',
                     WiFi_mode = WiFi_mode, rows = connections, WiFi_IP = WiFi_IP, WiFi_Passphrase = "!@#$%^&*", WiFi_State = WiFi_State, Host_IP = Host_IP)
 
 @route('/wireless', method='POST')
 def do_wireless_form():
     WiFiMode = _getWiFiMode()
-    WiFi_mode = request.forms.get('WiFi_mode')
+    WiFi_mode = request.forms.get('WiFi_mode', '')
     WiFi_Network = request.forms.get('newwifis')
     WiFi_Passphrase = request.forms.get('WiFipassphrase')
-    if WiFi_mode == "on":
+    if WiFi_mode == "checked":
         new_WiFiMode = "Connected"
     else:
         new_WiFiMode = "Off"
@@ -1057,11 +1057,11 @@ def ap_form():
 
 @route('/ap', method='POST')
 def do_ap_form():
-    AP_mode = request.forms.get('AP_mode', "")
+    AP_mode = request.forms.get('AP_mode', '')
     AP_name = request.forms.get('AP_name')
     AP_passphrase = request.forms.get('AP_passphrase')
 
-    if _getWiFiMode() != "AP" and AP_mode == "on":
+    if _getWiFiMode() != "AP" and AP_mode == "checked":
         if AP_name != _getAPSSID():
             if WSREGEX.search(AP_name):
                 return "The SSID must not contain whitespaces."

--- a/src/configure_edison
+++ b/src/configure_edison
@@ -189,12 +189,13 @@ def _getBTMode():
     return "Off"
 
 def _getGadgetMode():
-    modestr = ''
-    modestr = subprocess.run('lsusb', shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    modestr = str(modestr.stderr, 'utf-8')
-    gadget = modestr.find("unable to initialize libusb")
-    if gadget == -1:
+    try:
+        subprocess.check_output('dmesg | grep -q "usb0: link becomes ready"', shell=True)
+    except subprocess.CalledProcessError:
         return "None"
+    except Exception as inst:
+        return "Err"
+
     modestr = ''
     try:
         modestr = subprocess.check_output('connmanctl technologies', shell=True)
@@ -246,6 +247,19 @@ def _setBTMode(Mode):
     elif Mode == 'Powered':
         if CurrentMode == 'Off':
             subprocess.check_output("connmanctl enable bluetooth", shell=True)
+    time.sleep(1)
+    return
+
+def _setGadgetMode(Mode):
+    CurrentMode = _getGadgetMode()
+    if CurrentMode == 'Err':
+        return
+    if Mode == 'Off':
+        if CurrentMode != 'Off':
+            subprocess.check_output("connmanctl disable gadget", shell=True)
+    elif Mode == 'Powered':
+        if CurrentMode == 'Off':
+            subprocess.check_output("connmanctl enable gadget", shell=True)
     time.sleep(1)
     return
 
@@ -873,42 +887,42 @@ def do_name_form():
 def wired_form():
     global Settings
     Host_IP = request['REMOTE_ADDR']
-    if Settings.Wired.Changed == 0:
-        Net = _getGadgetMode()
+    Net = _getGadgetMode()
+    if Net == "None":
+        Net = _getWiredMode()
         if Net == "None":
-            Net = _getWiredMode()
-            if Net == "None":
-                Settings.Wired.Type = "No ethernet available"
-                Settings.Wired.IP = ""
-                Settings.Wired.Mode = "OFF"
-            elif Net == "Powered":
-                Settings.Wired.IP = "Not connected"
-                Settings.Wired.Type = "Ethernet dongle"
-                Settings.Wired.Mode = "Checked"
-            elif Net == "Connected":
-                Settings.Wired.IP = _getIFaceIP("eth0")
-                Settings.Wired.Type = "Ethernet dongle"
-                Settings.Wired.Mode = "Checked"
-            else:
-                Settings.Wired.Type = "An error has occured"
-                Settings.Wired.IP = ""
-                Settings.Wired.Mode = "OFF"
+            Settings.Wired.Type = "No ethernet available"
+            Settings.Wired.IP = ""
+            Settings.Wired.Mode = ""
         elif Net == "Powered":
             Settings.Wired.IP = "Not connected"
-            Settings.Wired.Type = "Ethernet over USB (OTG)"
-            Settings.Wired.Mode = "Checked"
+            Settings.Wired.Type = "Ethernet dongle"
+            Settings.Wired.Mode = "checked"
         elif Net == "Connected":
-            Settings.Wired.IP = _getIFaceIP("usb0")
-            Settings.Wired.Type = "Ethernet over USB (OTG)"
-            Settings.Wired.Mode = "Checked"
-        elif Net == "Off":
-            Settings.Wired.Type = "Ethernet over USB (OTG)"
-            Settings.Wired.IP = "Not powered"
-            Settings.Wired.Mode = "OFF"
+            Settings.Wired.IP = _getIFaceIP("eth0")
+            Settings.Wired.Type = "Ethernet dongle"
+            Settings.Wired.Mode = "checked"
         else:
             Settings.Wired.Type = "An error has occured"
             Settings.Wired.IP = ""
-            Settings.Wired.Mode = "OFF"
+            Settings.Wired.Mode = ""
+    elif Net == "Powered":
+        Settings.Wired.IP = "Not connected"
+        Settings.Wired.Type = "Ethernet over USB (OTG)"
+        Settings.Wired.Mode = "checked"
+    elif Net == "Connected":
+        Settings.Wired.IP = _getIFaceIP("usb0")
+        Settings.Wired.Type = "Ethernet over USB (OTG)"
+        Settings.Wired.Mode = "checked"
+    elif Net == "Off":
+        Settings.Wired.Type = "Ethernet over USB (OTG)"
+        Settings.Wired.IP = "Not powered"
+        Settings.Wired.Mode = ""
+    else:
+        Settings.Wired.Type = "An error has occured"
+        Settings.Wired.IP = ""
+        Settings.Wired.Mode = ""
+
     connections = _getServices("Wired")
     if connections:
         ConnState = connections[0][0]
@@ -921,7 +935,7 @@ def wired_form():
             Wired_State = "Primary connection verified On Line"
         elif "R" in ConnState:
             Wired_State = "Fall back connection standby"
-    if Net == "Powered":
+    elif Net == "Powered":
         if "*" in ConnState:
             Wired_State = "Connection available"
         else:
@@ -935,6 +949,10 @@ def do_wired_form():
     Settings.Wired.NewMode = request.forms.get('Wired_Mode', '')
     if Settings.Wired.NewMode != Settings.Wired.Mode:
         Settings.Wired.Changed = 1
+        if Settings.Wired.NewMode == "checked":
+            _setGadgetMode("Powered")
+        else:
+            _setGadgetMode("Off")
     else:
         Settings.Wired.Changed = 0
     redirect('/wired')

--- a/src/configure_edison
+++ b/src/configure_edison
@@ -236,6 +236,19 @@ def _setWiFiMode(Mode):
     time.sleep(1)
     return
 
+def _setBTMode(Mode):
+    CurrentMode = _getBTMode()
+    if CurrentMode == 'Err':
+        return
+    if Mode == 'Off':
+        if CurrentMode != 'Off':
+            subprocess.check_output("connmanctl disable bluetooth", shell=True)
+    elif Mode == 'Powered':
+        if CurrentMode == 'Off':
+            subprocess.check_output("connmanctl enable bluetooth", shell=True)
+    time.sleep(1)
+    return
+
 def _changeRootPassword(newPass):
   echoSub = subprocess.Popen(["echo", "root:" + newPass], stdout=subprocess.PIPE)
   chpasswdSub = subprocess.Popen(["chpasswd"], stdin=echoSub.stdout, stdout=subprocess.PIPE)
@@ -919,37 +932,38 @@ def wired_form():
 @route('/wired', method='POST')
 def do_wired_form():
     global Settings
-    Settings.Wired.NewMode = request.forms.get('Wired_Mode')
+    Settings.Wired.NewMode = request.forms.get('Wired_Mode', '')
     if Settings.Wired.NewMode != Settings.Wired.Mode:
         Settings.Wired.Changed = 1
+    else:
+        Settings.Wired.Changed = 0
     redirect('/wired')
 
 @route('/bt')
 def bt_form():
     global Settings
     Host_IP = request['REMOTE_ADDR']
-    if Settings.BT.Changed == 0:
-        Net = _getBTMode()
-        if Net == "None":
-            Settings.BT.Type = "No bluetooth available"
-            Settings.BT.IP = ""
-            Settings.BT.Mode = "OFF"
-        elif Net == "Powered":
-            Settings.BT.IP = "Not connected"
-            Settings.BT.Type = ""
-            Settings.BT.Mode = "Checked"
-        elif Net == "Connected":
-            Settings.BT.IP = _getIFaceIP("bnep0")
-            Settings.BT.Type = "Ethernet dongle"
-            Settings.BT.Mode = "Checked"
-        elif Net == "Off":
-            Settings.BT.Type = "Unknown"
-            Settings.BT.IP = "Not powered"
-            Settings.BT.Mode = "OFF"
-        else:
-            Settings.BT.Type = "An error has occured"
-            Settings.BT.IP = ""
-            Settings.BT.Mode = "OFF"
+    Net = _getBTMode()
+    if Net == "None":
+        Settings.BT.Type = "No bluetooth available"
+        Settings.BT.IP = ""
+        Settings.BT.Mode = ""
+    elif Net == "Powered":
+        Settings.BT.IP = "Not connected"
+        Settings.BT.Type = ""
+        Settings.BT.Mode = "checked"
+    elif Net == "Connected":
+        Settings.BT.IP = _getIFaceIP("bnep0")
+        Settings.BT.Type = "NAP"
+        Settings.BT.Mode = "checked"
+    elif Net == "Off":
+        Settings.BT.Type = "Unknown"
+        Settings.BT.IP = "Not powered"
+        Settings.BT.Mode = ""
+    else:
+        Settings.BT.Type = "An error has occured"
+        Settings.BT.IP = ""
+        Settings.BT.Mode = ""
 
     connections = _getServices("bluetooth")
     if connections:
@@ -963,7 +977,7 @@ def bt_form():
             BT_State = "Primary connection verified On Line"
         elif "R" in ConnState:
             BT_State = "Fall back connection standby"
-    if Net == "Powered":
+    elif Net == "Powered":
         if "*" in ConnState:
             BT_State = "Connection available"
         else:
@@ -974,9 +988,15 @@ def bt_form():
 @route('/bt', method='POST')
 def do_bt_form():
     global Settings
-    Settings.BT.NewMode = request.forms.get('BT_Mode')
+    Settings.BT.NewMode = request.forms.get('BT_Mode', '')
     if Settings.BT.NewMode != Settings.BT.Mode:
         Settings.BT.Changed = 1
+        if Settings.BT.NewMode == "checked":
+            _setBTMode("Powered")
+        else:
+            _setBTMode("Off")
+    else:
+        Settings.BT.Changed = 0
     redirect('/bt')
 
 @route('/wireless')

--- a/src/public/ap.tpl
+++ b/src/public/ap.tpl
@@ -36,7 +36,7 @@
                 <td class="middle">
                     <BR>
                     <div class="can-toggle demo-rebrand-2">
-                        <input id="ap" type="checkbox" name="AP_mode" {{AP_mode}}>
+                        <input id="ap" type="checkbox" name="AP_mode" value="checked" {{AP_mode}}>
                         <label for="ap">
                             <div class="can-toggle__switch" data-checked="ON" data-unchecked="OFF"></div>
                             <div class="can-toggle__label-text">{{AP_IP}}</div>

--- a/src/public/ap.tpl
+++ b/src/public/ap.tpl
@@ -4,6 +4,12 @@
     <title>Edison Setup</title>
     <link rel="stylesheet" href="css/main.css" media="screen"/>
     <script src="script/script.js"></script>
+    <script>
+        function toggleAP(e) {
+            document.getElementById('name').readOnly = !e.target.checked
+            document.getElementById('passphrase').readOnly = !e.target.checked
+        }
+    </script>
 </head>
 <body>
 <a href="/" style="text-decoration: none"><h1>Edison Setup</h1></a>
@@ -36,7 +42,7 @@
                 <td class="middle">
                     <BR>
                     <div class="can-toggle demo-rebrand-2">
-                        <input id="ap" type="checkbox" name="AP_mode" value="checked" {{AP_mode}}>
+                        <input id="ap" type="checkbox" name="AP_mode" onchange="toggleAP(event)" value="checked" {{AP_mode}}>
                         <label for="ap">
                             <div class="can-toggle__switch" data-checked="ON" data-unchecked="OFF"></div>
                             <div class="can-toggle__label-text">{{AP_IP}}</div>
@@ -54,7 +60,7 @@
                     <label for="name">AP Name:</label>
                 </td>
                 <td class="right">
-                    <input type="text" id="name" name="AP_name" value="{{AP_name}}" class="textbox">
+                    <input type="text" id="name" name="AP_name" value="{{AP_name}}" class="textbox" readonly>
                 </td>
             </tr>
             <tr>
@@ -65,7 +71,7 @@
                     <label for="passphrase">AP Passphrase:</label>
                 </td>
                 <td class="right">
-                    <input type="password" id="passphrase" name="AP_passphrase" value="{{AP_passphrase}}" class="textbox">
+                    <input type="password" id="passphrase" name="AP_passphrase" value="{{AP_passphrase}}" class="textbox" readonly>
                 </td>
             </tr>
         </table>

--- a/src/public/bt.tpl
+++ b/src/public/bt.tpl
@@ -35,8 +35,8 @@
                 </td>
                 <td class="middle">
                     <BR>
-                    <div class="can-toggle demo-rebrand-2"><!-- should be converted back into a checkbox -->
-                        <input id="wired" type="text" readonly="1" name="BT_Mode" value="{{BT_Mode}}">
+                    <div class="can-toggle demo-rebrand-2">
+                        <input id="wired" type="checkbox" name="BT_Mode" value="checked" {{BT_Mode}}>
                         <label for="wired">
                             <div class="can-toggle__switch" data-checked="ON" data-unchecked="OFF"></div>
                             <div class="can-toggle__label-text">{{BT_IP}}</div>
@@ -45,14 +45,12 @@
                 </td>
                 <td class="right">
                     <BR>
-                    <label for="wired">{{BT_Type}}</label>
+                    <label for="wired">{{BT_State}}</label>
                 </td>
             </tr>
             <tr>
                 <td class="left">
-<!--
-                    Edison supports a wired connection over USB using an OTG cable (breakout board) or by placing the switch in Gadget mode (Edison Arduino board). Alternatively, plug a (USB) ethernet dongle. The type is detected automatically.
--->
+                    Edison supports a wireless connection over BT by pairing with a smartphone and enabling the BT tethering mode to gain Internet access.
                 </td>
                 <td class="middle">
                     <label>Network Type:</label>
@@ -60,8 +58,8 @@
                 <td class="right">
                     {{BT_Type}}
                 </td>
-            <tr>
             </tr>
+            <tr>
                 <td class="left">
                     <i><p>Changing the Bluetooth network will interrupt your connection if you are currently using this to access the Edison.</p>
                     <p>Consider setting up a WiFi connection as a fallback before doing this.</p>

--- a/src/public/wired.tpl
+++ b/src/public/wired.tpl
@@ -35,8 +35,8 @@
                 </td>
                 <td class="middle">
                     <BR>
-                    <div class="can-toggle demo-rebrand-2"><!-- should be converted back into a checkbox -->
-                        <input id="wired" type="text" readonly="1" name="Wired_Mode" value="{{Wired_Mode}}">
+                    <div class="can-toggle demo-rebrand-2">
+                        <input id="wired" type="checkbox" name="Wired_Mode" value="checked" {{Wired_Mode}}>
                         <label for="wired">
                             <div class="can-toggle__switch" data-checked="ON" data-unchecked="OFF"></div>
                             <div class="can-toggle__label-text">{{Wired_IP}}</div>
@@ -58,8 +58,8 @@
                 <td class="right">
                     {{Wired_Type}}
                 </td>
-            <tr>
             </tr>
+            <tr>
                 <td class="left">
                     <i><p>Changing the Wired network will interrupt your connection if you are currently using this to access the Edison.</p>
                     <p>Consider setting up a WiFi connection as a fallback before doing this.</p>

--- a/src/public/wireless.tpl
+++ b/src/public/wireless.tpl
@@ -36,7 +36,7 @@
                 <td class="middle">
                     <BR>
                     <div class="can-toggle demo-rebrand-2">
-                        <input id="wifi" type="checkbox" name="WiFi_mode" {{WiFi_mode}}>
+                        <input id="wifi" type="checkbox" name="WiFi_mode" value="checked" {{WiFi_mode}}>
                         <label for="wifi">
                             <div class="can-toggle__switch" data-checked="ON" data-unchecked="OFF"></div>
                             <div class="can-toggle__label-text">{{WiFi_IP}}</div>
@@ -60,9 +60,10 @@
                         %for row in rows:
                             <option value="{{row[2]}}">{{row[1]}}</option>
                         %end
+                    </select>
                 </td>
-            <tr>
             </tr>
+            <tr>
                 <td class="left">
                     <i><p>Changing the WiFi network will interrupt your connection if you are currently using this to access the Edison. </p>
                     <p>Consider setting up a wired connection as a fallback before doing this.</p>

--- a/src/public/wirelessr.tpl
+++ b/src/public/wirelessr.tpl
@@ -37,7 +37,7 @@
                 <td class="middle">
                     <BR>
                     <div class="can-toggle demo-rebrand-2">
-                        <input id="wifi" type="checkbox" name="WiFi_mode" {{WiFi_mode}}>
+                        <input id="wifi" type="checkbox" name="WiFi_mode" value="checked" {{WiFi_mode}}>
                         <label for="wifi">
                             <div class="can-toggle__switch" data-checked="ON" data-unchecked="OFF"></div>
                             <div class="can-toggle__label-text">{{WiFi_IP}}</div>
@@ -61,9 +61,10 @@
                         %for row in rows:
                             <option value="{{row[2]}}">{{row[1]}}</option>
                         %end
+                    </select>
                 </td>
-            <tr>
             </tr>
+            <tr>
                 <td class="left">
                     <i><p>Changing the WiFi network will interrupt your connection if you are currently using this to access the Edison. </p>
                     <p>Consider setting up a wired connection as a fallback before doing this.</p>


### PR DESCRIPTION
* Wired (= gadet) + BT adapter may be enabled/disabled properly
* AP settings get greyed out when it is offline/in use (they wouldn't get applied)

TODO
* Connman service selection (still required to be done on the cmdline)
* Connection settings get applied immediately, not after clicking the submit button on the last form (don't know if the current behaviour is better)