### PR TITLE
configure_edison: fix wifi address detection in cmdline mode

### DIFF
--- a/src/configure_edison
+++ b/src/configure_edison
@@ -618,8 +618,8 @@ def _checkNetwork():
     stdout.write(waiting)
     stdout.flush()
     time.sleep(1)
-    address = os.popen("ifconfig | grep -A1 'wlan0' | grep 'inet'| awk -F' ' '{ print $2 }' | awk -F':' '{ print $2 }'").read().rstrip()
-    if not address == "":
+    address = _getIFaceIP("wlan0")
+    if not address == "none":
       print("Done. Please connect your laptop or PC to the same network as this device and go to " + \
         text_colors.CYAN + "http://" + address + text_colors.END + " or " + text_colors.CYAN + \
         "http://" + _getHostName() + ".local" + text_colors.END + \

--- a/src/configure_edison
+++ b/src/configure_edison
@@ -286,7 +286,7 @@ def _getIFaceIP(iface):
             struct.pack('256s', iface[:15].encode('utf-8'))
         )[20:24])
     except OSError:
-        return "none"
+        return "None"
     finally:
         s.close()
 
@@ -619,7 +619,7 @@ def _checkNetwork():
     stdout.flush()
     time.sleep(1)
     address = _getIFaceIP("wlan0")
-    if not address == "none":
+    if address != 'None':
       print("Done. Please connect your laptop or PC to the same network as this device and go to " + \
         text_colors.CYAN + "http://" + address + text_colors.END + " or " + text_colors.CYAN + \
         "http://" + _getHostName() + ".local" + text_colors.END + \
@@ -669,7 +669,7 @@ def showWiFiIP():
     if _getWiFiMode() == 'AP':
         return _getIFaceIP("tether")
     ipstr = _getIFaceIP('wlan0')
-    if ipstr == 'none':
+    if ipstr == 'None':
         print("No IP address found. Device not connected?")
     return ipstr
 


### PR DESCRIPTION
Very important to get this in all recent Yocto releases including *dunfell*, it brake with the esthetical update of `ifconfig`.

Please re-test it @htot, just run `configure_edison --wifi`.